### PR TITLE
Add cls command

### DIFF
--- a/CommandInfrastructure/ConsoleOutput.cs
+++ b/CommandInfrastructure/ConsoleOutput.cs
@@ -31,6 +31,7 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
         {
             Console.Write(s_prompt);
             m_numberLinesWritten = 0;
+            m_windowHeight = Console.WindowHeight;
             m_cancellationRequested = false;
         }
 

--- a/Commands/ClearConsoleCommand.cs
+++ b/Commands/ClearConsoleCommand.cs
@@ -1,0 +1,18 @@
+﻿// Copyright(c) Meta Platforms, Inc. and affiliates.
+
+using MemorySnapshotAnalyzer.CommandProcessing;
+
+namespace MemorySnapshotAnalyzer.Commands
+{
+    public class ClearConsoleCommand : Command
+    {
+        public ClearConsoleCommand(Repl repl) : base(repl) { }
+
+        public override void Run()
+        {
+            Output.Clear();
+        }
+
+        public override string HelpText => "cls";
+    }
+}

--- a/MemorySnapshotAnalyzer/Program.cs
+++ b/MemorySnapshotAnalyzer/Program.cs
@@ -22,6 +22,7 @@ static class Program
 
         repl.AddCommand(typeof(HelpCommand), "help");
         repl.AddCommand(typeof(ExitCommand), "exit");
+        repl.AddCommand(typeof(ClearConsoleCommand), "cls");
         repl.AddCommand(typeof(ContextCommand), "context");
         repl.AddCommand(typeof(OptionsCommand), "options");
         repl.AddCommand(typeof(LoadCommand), "load");


### PR DESCRIPTION
## Issue Description

When resizing the console window, output could get messed up.

## Change Description

Added a `cls` command to clear the console, and retrieve updated window height.