### PR TITLE
Include field names in bt 'shortestpaths

### DIFF
--- a/Commands/BacktraceCommand.cs
+++ b/Commands/BacktraceCommand.cs
@@ -198,8 +198,18 @@ namespace MemorySnapshotAnalyzer.Commands
                     int[] path = shortestPaths[rootNodeIndex];
                     for (int i = path.Length - 1; i >= 0; i--)
                     {
-                        Output.WriteLineIndented(i == path.Length - 1 ? 0 : 1,
-                            CurrentBacktracer.DescribeNodeIndex(path[i], FullyQualified));
+                        int thisNodeIndex = path[i];
+                        int successorNodeIndex = i > 0 ? path[i - 1] : -1;
+
+                        string fields = "";
+                        if (Fields && successorNodeIndex != -1 && CurrentBacktracer.IsLiveObjectNode(thisNodeIndex))
+                        {
+                            fields = CollectFields(thisNodeIndex, successorNodeIndex);
+                        }
+
+                        Output.WriteLineIndented(i == path.Length - 1 ? 0 : 1, "{0}{1}",
+                            CurrentBacktracer.DescribeNodeIndex(thisNodeIndex, FullyQualified),
+                            fields);
                     }
                 }
             }


### PR DESCRIPTION
## Issue Description

When identifying the reason for a specific object to have been leaked, it is useful to run `bt 'shortestpaths`. However, this variant of the command did not respect the `'fields` option, slowing down the diagnostic workflow.

## Change Description

Added field output to `bt 'shortestpaths`.