### PR TITLE
Better VSCode and shell integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+*.snap
+*References.txt
+appsettings.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/CommandInfrastructure/CommandInfrastructure.csproj
+++ b/CommandInfrastructure/CommandInfrastructure.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="ReadLine" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandInfrastructure/FileOutput.cs
+++ b/CommandInfrastructure/FileOutput.cs
@@ -29,7 +29,19 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
             }
         }
 
+        void IOutput.SetPrompt(string prompt)
+        {
+        }
+
         void IOutput.Prompt()
+        {
+        }
+
+        void IOutput.ExecutionStart()
+        {
+        }
+
+        void IOutput.ExecutionEnd(int exitCode)
         {
         }
 

--- a/CommandInfrastructure/IOutput.cs
+++ b/CommandInfrastructure/IOutput.cs
@@ -4,7 +4,13 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
 {
     public interface IOutput
     {
+        void SetPrompt(string prompt);
+
         void Prompt();
+
+        void ExecutionStart();
+
+        void ExecutionEnd(int exitCode);
 
         void Clear();
 

--- a/CommandInfrastructure/Repl.cs
+++ b/CommandInfrastructure/Repl.cs
@@ -44,6 +44,7 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
                 Backtracer_WeakDelegates = configuration.GetValue<bool>("WeakDelegates")
             });
             m_currentContextId = 0;
+            Output.SetPrompt("[0]> ");
         }
 
         public void Dispose()
@@ -96,6 +97,7 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
                 m_contexts.Add(id, Context.WithSameOptionsAs(m_contexts[m_currentContextId], id));
             }
             m_currentContextId = id;
+            Output.SetPrompt($"[{id}]> ");
             return m_contexts[id];
         }
 
@@ -123,10 +125,11 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
 
         public void Run()
         {
+            ReadLine.HistoryEnabled = true;
             while (true)
             {
                 Output.Prompt();
-                string? line = Console.ReadLine();
+                string? line = ReadLine.Read();
                 if (line == null)
                 {
                     continue;
@@ -143,19 +146,24 @@ namespace MemorySnapshotAnalyzer.CommandProcessing
 
             try
             {
+                Output.ExecutionStart();
                 RunCommand(line);
+                Output.ExecutionEnd(0);
             }
             catch (OperationCanceledException)
             {
                 Output.WriteLine("canceled");
+                Output.ExecutionEnd(1);
             }
             catch (InvalidSnapshotFormatException ex)
             {
                 Output.WriteLine(ex.Message);
+                Output.ExecutionEnd(1);
             }
             catch (CommandException ex)
             {
                 Output.WriteLine(ex.Message);
+                Output.ExecutionEnd(1);
             }
 
             m_currentCommandLine = null;

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cp MemorySnapshotAnalyzer/appsettings.json .
+exec dotnet run --project MemorySnapshotAnalyzer/MemorySnapshotAnalyzer.csproj


### PR DESCRIPTION
## Issue Description

On MacOS/Linux, the console app had no command line editing or history.

## Change Description

* Use ReadLine library
* VSCode terminal integration (prompt navigation; success/failure indication)
* `run.sh` wrapper to easily build and run from the command line
* Added some entries to `.gitignore` to allow for snapshot files and reference classifiers in the working directory