### PR TITLE
Add EXTERNAL rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 *.snap
-*References.txt
+*.rcl
 appsettings.json
 
 # User-specific files

--- a/AbstractMemorySnapshot/PointerInfo.cs
+++ b/AbstractMemorySnapshot/PointerInfo.cs
@@ -8,6 +8,7 @@ namespace MemorySnapshotAnalyzer.AbstractMemorySnapshot
         IsOwningReference = 1 << 0,
         IsConditionAnchor = 1 << 1,
         IsWeakReference = 1 << 2,
+        IsExternalReference = 1 << 3,
     }
 
     public struct PointerInfo<T>

--- a/AbstractMemorySnapshot/SegmentedHeap.cs
+++ b/AbstractMemorySnapshot/SegmentedHeap.cs
@@ -29,8 +29,8 @@ namespace MemorySnapshotAnalyzer.AbstractMemorySnapshot
             m_segments = segments;
         }
 
-        // This method provides an implementation for TraceableHeap.GetIntraHeapPointers, for heaps whose memory we have access to.
-        public IEnumerable<PointerInfo<NativeWord>> GetIntraHeapPointers(NativeWord address, int typeIndex)
+        // This method provides an implementation for TraceableHeap.GetPointers, for heaps whose memory we have access to.
+        public IEnumerable<PointerInfo<NativeWord>> GetPointers(NativeWord address, int typeIndex)
         {
             MemoryView objectView = GetMemoryViewForAddress(address);
             if (m_typeSystem.IsArray(typeIndex))

--- a/AbstractMemorySnapshot/TraceableHeap.cs
+++ b/AbstractMemorySnapshot/TraceableHeap.cs
@@ -33,9 +33,29 @@ namespace MemorySnapshotAnalyzer.AbstractMemorySnapshot
 
         public abstract string? GetObjectName(NativeWord objectAddress);
 
-        public abstract IEnumerable<PointerInfo<NativeWord>> GetIntraHeapPointers(NativeWord address, int typeIndex);
+        public abstract IEnumerable<PointerInfo<NativeWord>> GetPointers(NativeWord address, int typeIndex);
 
-        public abstract IEnumerable<NativeWord> GetInterHeapPointers(NativeWord address, int typeIndex);
+        public IEnumerable<PointerInfo<NativeWord>> GetIntraHeapPointers(NativeWord address, int typeIndex)
+        {
+            foreach (PointerInfo<NativeWord> pointerInfo in GetPointers(address, typeIndex))
+            {
+                if ((pointerInfo.PointerFlags & PointerFlags.IsExternalReference) == 0)
+                {
+                    yield return pointerInfo;
+                }
+            }
+        }
+
+        public IEnumerable<PointerInfo<NativeWord>> GetInterHeapPointers(NativeWord address, int typeIndex)
+        {
+            foreach (PointerInfo<NativeWord> pointerInfo in GetPointers(address, typeIndex))
+            {
+                if ((pointerInfo.PointerFlags & PointerFlags.IsExternalReference) != 0)
+                {
+                    yield return pointerInfo;
+                }
+            }
+        }
 
         public abstract IEnumerable<(NativeWord childObjectAddress, NativeWord parentObjectAddress)> GetOwningReferencesFromAnchor(NativeWord anchorObjectAddress, PointerInfo<NativeWord> pointerInfo);
 

--- a/CommandInfrastructure/Command.cs
+++ b/CommandInfrastructure/Command.cs
@@ -254,7 +254,7 @@ namespace MemorySnapshotAnalyzer.CommandInfrastructure
                 typeIndex);
 
             var sb = new StringBuilder();
-            foreach (PointerInfo<NativeWord> pointerInfo in CurrentTraceableHeap.GetIntraHeapPointers(address, typeIndex))
+            foreach (PointerInfo<NativeWord> pointerInfo in CurrentTraceableHeap.GetPointers(address, typeIndex))
             {
                 DescribeAddress(pointerInfo.Value, sb);
                 if (sb.Length > 0)
@@ -267,16 +267,6 @@ namespace MemorySnapshotAnalyzer.CommandInfrastructure
                     {
                         Output.WriteLineIndented(1, sb.ToString());
                     }
-                    sb.Clear();
-                }
-            }
-
-            foreach (NativeWord reference in CurrentTraceableHeap.GetInterHeapPointers(address, typeIndex))
-            {
-                DescribeAddress(reference, sb);
-                if (sb.Length > 0)
-                {
-                    Output.WriteLineIndented(1, "cross-heap {0}", sb.ToString());
                     sb.Clear();
                 }
             }

--- a/Commands/ReferenceClassifierCommand.cs
+++ b/Commands/ReferenceClassifierCommand.cs
@@ -167,6 +167,6 @@ namespace MemorySnapshotAnalyzer.Commands
             }
         }
 
-        public override string HelpText => "referenceclassifier ['clear | 'load <filename> | 'list ['verbose] | 'enable | 'disable] ['group (<prefix*>|<name>),...]]";
+        public override string HelpText => "referenceclassifier ('clear | 'load <filename> | 'list ['verbose] | 'enable | 'disable) (<prefix*>|<name>),...";
     }
 }

--- a/MemorySnapshotAnalyzer/thirdparty.rcl
+++ b/MemorySnapshotAnalyzer/thirdparty.rcl
@@ -47,6 +47,12 @@
 [thirdparty.unity]
 
 ##
+## Connection between managed and native objects
+##
+
+"UnityEngine.CoreModule.dll:UnityEngine.Object" EXTERNAL "m_CachedPtr";
+
+##
 ## Input
 ##
 

--- a/ReferenceClassifiers/BoundRuleset.cs
+++ b/ReferenceClassifiers/BoundRuleset.cs
@@ -9,76 +9,61 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
     sealed class BoundRuleset
     {
         readonly TypeSystem m_typeSystem;
-        readonly HashSet<(int typeIndex, int fieldNumber)> m_owningReferences;
+        readonly Dictionary<(int typeIndex, int fieldNumber), PointerFlags> m_specialReferences;
         readonly Dictionary<(int typeIndex, int fieldNumber), List<(int typeIndex, int fieldNumber)[]>> m_conditionAnchors;
-        readonly HashSet<(int typeIndex, int fieldNumber)> m_weakReferences;
 
         internal BoundRuleset(TypeSystem typeSystem, List<Rule> rules)
         {
             m_typeSystem = typeSystem;
-            m_owningReferences = new();
+            m_specialReferences = new();
             m_conditionAnchors = new();
-            m_weakReferences = new();
 
-            var shallowSpecs = new List<(TypeSpec spec, string fieldPattern, int ruleNumber)>();
-            var deepSpecs = new List<(TypeSpec spec, string fieldName, int ruleNumber)>();
-            var weakSpecs = new List<(TypeSpec spec, string fieldName, int ruleNumber)>();
+            List<(TypeSpec spec, string fieldPattern, (int ruleNumber, PointerFlags pointerFlags))> specs = new();
             for (int ruleNumber = 0; ruleNumber < rules.Count; ruleNumber++)
             {
                 if (rules[ruleNumber] is OwnsFieldPatternRule fieldPatternRule)
                 {
-                    shallowSpecs.Add((fieldPatternRule.TypeSpec, fieldPatternRule.FieldPattern, ruleNumber));
+                    specs.Add((fieldPatternRule.TypeSpec, fieldPatternRule.FieldPattern, (ruleNumber, PointerFlags.IsOwningReference)));
                 }
                 else if (rules[ruleNumber] is OwnsFieldPathRule fieldPathRule)
                 {
-                    deepSpecs.Add((fieldPathRule.TypeSpec, fieldPathRule.Selector[0], ruleNumber));
+                    specs.Add((fieldPathRule.TypeSpec, fieldPathRule.Selector[0], (ruleNumber, PointerFlags.IsConditionAnchor)));
                 }
                 else if (rules[ruleNumber] is WeakRule weakRule)
                 {
-                    weakSpecs.Add((weakRule.TypeSpec, weakRule.FieldPattern, ruleNumber));
+                    specs.Add((weakRule.TypeSpec, weakRule.FieldPattern, (ruleNumber, PointerFlags.IsWeakReference)));
+                }
+                else if (rules[ruleNumber] is ExternalRule externalRule)
+                {
+                    specs.Add((externalRule.TypeSpec, externalRule.FieldPattern, (ruleNumber, PointerFlags.IsExternalReference)));
                 }
             }
 
-            var owningReferenceMatcher = new Matcher(m_typeSystem, shallowSpecs);
-            var anchorMatcher = new Matcher(m_typeSystem, deepSpecs);
-            var weakMatcher = new Matcher(m_typeSystem, weakSpecs);
+            var matcher = new Matcher<(int ruleNumber, PointerFlags pointerFlags)>(m_typeSystem, specs);
+
+            var processField = (int typeIndex, int fieldNumber, (int ruleNumber, PointerFlags pointerFlags) data) =>
+            {
+                m_specialReferences.Add((typeIndex, fieldNumber), data.pointerFlags);
+
+                if (rules[data.ruleNumber] is OwnsFieldPathRule ownsFieldPathRule)
+                {
+                    if (!m_conditionAnchors.TryGetValue((typeIndex, fieldNumber), out List<(int typeIndex, int fieldNumber)[]>? fieldPaths))
+                    {
+                        fieldPaths = new();
+                        m_conditionAnchors.Add((typeIndex, fieldNumber), fieldPaths);
+                    }
+
+                    var fieldPath = FindFieldPath(typeIndex, ownsFieldPathRule.Selector);
+                    if (fieldPath != null)
+                    {
+                        fieldPaths.Add(fieldPath);
+                    }
+                }
+            };
 
             for (int typeIndex = 0; typeIndex < typeSystem.NumberOfTypeIndices; typeIndex++)
             {
-                var owningReferenceFieldPatterns = owningReferenceMatcher.GetFieldPatterns(typeIndex);
-                if (owningReferenceFieldPatterns != null)
-                {
-                    ClassifyFields(typeIndex, owningReferenceFieldPatterns,
-                        (fieldNumber, ruleNumber) => m_owningReferences.Add((typeIndex, fieldNumber)));
-                }
-
-                var anchorFieldPatterns = anchorMatcher.GetFieldPatterns(typeIndex);
-                if (anchorFieldPatterns != null)
-                {
-                    ClassifyFields(typeIndex, anchorFieldPatterns,
-                        (fieldNumber, ruleNumber) =>
-                        {
-                            var fieldPathRule = (OwnsFieldPathRule)rules[ruleNumber];
-                            var fieldPath = FindFieldPath(typeIndex, fieldPathRule.Selector!);
-                            if (fieldPath != null)
-                            {
-                                if (!m_conditionAnchors.TryGetValue((typeIndex, fieldNumber), out List<(int typeIndex, int fieldNumber)[]>? fieldPaths))
-                                {
-                                    fieldPaths = new List<(int typeIndex, int fieldNumber)[]>();
-                                    m_conditionAnchors.Add((typeIndex, fieldNumber), fieldPaths);
-                                }
-
-                                fieldPaths.Add(fieldPath);
-                            }
-                        });
-                }
-
-                var weakFieldPatterns = weakMatcher.GetFieldPatterns(typeIndex);
-                if (weakFieldPatterns != null)
-                {
-                    ClassifyFields(typeIndex, weakFieldPatterns,
-                        (fieldNumber, ruleNumber) => m_weakReferences.Add((typeIndex, fieldNumber)));
-                }
+                matcher.ForAllMatchingFields(typeIndex, processField);
             }
         }
 
@@ -136,39 +121,16 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
             return fieldPath;
         }
 
-        void ClassifyFields(int typeIndex, List<(string fieldPattern, int ruleNumber)> fieldPatterns, Action<int, int> add)
-        {
-            int numberOfFields = m_typeSystem.NumberOfFields(typeIndex);
-            for (int fieldNumber = 0; fieldNumber < numberOfFields; fieldNumber++)
-            {
-                string fieldName = m_typeSystem.FieldName(typeIndex, fieldNumber);
-                int ruleNumber = Matcher.TestFieldName(fieldName, fieldPatterns);
-                if (ruleNumber != -1)
-                {
-                    add(fieldNumber, ruleNumber);
-                }
-            }
-        }
-
         internal PointerFlags GetPointerFlags(int typeIndex, int fieldNumber)
         {
-            PointerFlags pointerFlags = PointerFlags.None;
-            if (m_owningReferences.Contains((typeIndex, fieldNumber)))
+            if (m_specialReferences.TryGetValue((typeIndex, fieldNumber), out PointerFlags pointerFlags))
             {
-                pointerFlags |= PointerFlags.IsOwningReference;
+                return pointerFlags;
             }
-
-            if (m_conditionAnchors.ContainsKey((typeIndex, fieldNumber)))
+            else
             {
-                pointerFlags |= PointerFlags.IsConditionAnchor;
+                return PointerFlags.None;
             }
-
-            if (m_weakReferences.Contains((typeIndex, fieldNumber)))
-            {
-                pointerFlags |= PointerFlags.IsWeakReference;
-            }
-
-            return pointerFlags;
         }
 
         internal List<(int typeIndex, int fieldNumber)[]> GetConditionalAnchorFieldPaths(int typeIndex, int fieldNumber)

--- a/ReferenceClassifiers/ReferenceClassifierParser.cs
+++ b/ReferenceClassifiers/ReferenceClassifierParser.cs
@@ -87,6 +87,12 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
                         AddRule(WeakRule.Parse(typeSpec, m_enumerator.Current.value));
                         break;
                     case ReferenceClassifierFileTokenizer.Token.External:
+                        if (!m_enumerator.MoveNext() || m_enumerator.Current.token != ReferenceClassifierFileTokenizer.Token.String)
+                        {
+                            throw new FileFormatException("EXTERNAL must be followed by field pattern");
+                        }
+                        AddRule(ExternalRule.Parse(typeSpec, m_enumerator.Current.value));
+                        break;
                     case ReferenceClassifierFileTokenizer.Token.FuseWith:
                     case ReferenceClassifierFileTokenizer.Token.TagIfZero:
                     case ReferenceClassifierFileTokenizer.Token.TagIfNonZero:

--- a/ReferenceClassifiers/Rules.cs
+++ b/ReferenceClassifiers/Rules.cs
@@ -155,9 +155,8 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
 
         public override string ToString()
         {
-            StringBuilder sb = new(TypeSpec.ToString());
-            sb.Append(" OWNS \"");
-            foreach (string fieldName in Selector!)
+            StringBuilder sb = new();
+            foreach (string fieldName in Selector)
             {
                 if (sb.Length > 0 && !fieldName.Equals("[]", StringComparison.Ordinal))
                 {
@@ -165,8 +164,7 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
                 }
                 sb.Append(fieldName);
             }
-            sb.Append("\";");
-            return sb.ToString();
+            return $"{TypeSpec} OWNS \"{sb}\";";
         }
     }
 
@@ -188,6 +186,27 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
         public override string ToString()
         {
             return $"{TypeSpec} WEAK \"{FieldPattern}\";";
+        }
+    }
+
+    public sealed class ExternalRule : Rule
+    {
+        // A field name, or (if ending in "*") a field prefix.
+        public string FieldPattern { get; private set; }
+
+        public ExternalRule(TypeSpec typeSpec, string fieldPattern) : base(typeSpec)
+        {
+            FieldPattern = fieldPattern;
+        }
+
+        public static ExternalRule Parse(TypeSpec typeSpec, string value)
+        {
+            return new ExternalRule(typeSpec, value);
+        }
+
+        public override string ToString()
+        {
+            return $"{TypeSpec} EXTERNAL \"{FieldPattern}\";";
         }
     }
 }

--- a/UnityBackend/UnityManagedHeap.cs
+++ b/UnityBackend/UnityManagedHeap.cs
@@ -40,7 +40,7 @@ namespace MemorySnapshotAnalyzer.UnityBackend
         }
 
         public override int NumberOfGCHandles => m_gcHandleTargets.Length;
-    
+
         public override NativeWord GCHandleTarget(int gcHandleIndex)
         {
             return Native.From(m_gcHandleTargets[gcHandleIndex]);
@@ -92,18 +92,9 @@ namespace MemorySnapshotAnalyzer.UnityBackend
             return null;
         }
 
-        public override IEnumerable<PointerInfo<NativeWord>> GetIntraHeapPointers(NativeWord address, int typeIndex)
+        public override IEnumerable<PointerInfo<NativeWord>> GetPointers(NativeWord address, int typeIndex)
         {
-            return m_segmentedHeap.GetIntraHeapPointers(address, typeIndex);
-        }
-
-        public override IEnumerable<NativeWord> GetInterHeapPointers(NativeWord address, int typeIndex)
-        {
-            if (m_unityManagedTypeSystem.IsUnityEngineType(typeIndex))
-            {
-                MemoryView objectView = m_segmentedHeap.GetMemoryViewForAddress(address);
-                yield return objectView.ReadPointer(m_unityManagedTypeSystem.UnityEngineCachedPtrFieldOffset, Native);
-            }
+            return m_segmentedHeap.GetPointers(address, typeIndex);
         }
 
         public override IEnumerable<(NativeWord childObjectAddress, NativeWord parentObjectAddress)> GetOwningReferencesFromAnchor(NativeWord anchorObjectAddress, PointerInfo<NativeWord> pointerInfo)

--- a/UnityBackend/UnityNativeObjectHeap.cs
+++ b/UnityBackend/UnityNativeObjectHeap.cs
@@ -90,7 +90,7 @@ namespace MemorySnapshotAnalyzer.UnityBackend
             return m_nativeObjectsByAddress[objectAddress.Value].Name;
         }
 
-        public override IEnumerable<PointerInfo<NativeWord>> GetIntraHeapPointers(NativeWord address, int typeIndex)
+        public override IEnumerable<PointerInfo<NativeWord>> GetPointers(NativeWord address, int typeIndex)
         {
             int instanceId = m_nativeObjectsByAddress[address.Value].InstanceId;
             if (m_connections.TryGetValue(instanceId, out List<int>? successorInstanceIds))
@@ -106,11 +106,6 @@ namespace MemorySnapshotAnalyzer.UnityBackend
                     };
                 }
             }
-        }
-
-        public override IEnumerable<NativeWord> GetInterHeapPointers(NativeWord address, int typeIndex)
-        {
-            return Array.Empty<NativeWord>();
         }
 
         public override IEnumerable<(NativeWord childObjectAddress, NativeWord parentObjectAddress)> GetOwningReferencesFromAnchor(NativeWord anchorObjectAddress, PointerInfo<NativeWord> pointerInfo)

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 cp MemorySnapshotAnalyzer/appsettings.json .
+cp MemorySnapshotAnalyzer/thirdparty.rcl .
 exec dotnet run --project MemorySnapshotAnalyzer/MemorySnapshotAnalyzer.csproj


### PR DESCRIPTION
## Issue Description

Previously, the way that managed & native heaps are interlinked needed to be special-cased by the backend.

## Change Description

A new `EXTERNAL` rule allows for the locations of native pointers within managed objects to be configured.