### PR TITLE
Ensure that bt 'lifelines outputs tags target object

### DIFF
--- a/Commands/BacktraceCommand.cs
+++ b/Commands/BacktraceCommand.cs
@@ -109,7 +109,7 @@ namespace MemorySnapshotAnalyzer.Commands
         bool DumpBacktraceLine(int nodeIndex, HashSet<int> ancestors, HashSet<int> seen, int indent, int successorNodeIndex, string prefix)
         {
             string fields = "";
-            if (Fields && successorNodeIndex != -1 && CurrentBacktracer.IsLiveObjectNode(nodeIndex))
+            if (Fields && CurrentBacktracer.IsLiveObjectNode(nodeIndex))
             {
                 fields = CollectFieldsAndTags(nodeIndex, successorNodeIndex);
             }
@@ -149,20 +149,24 @@ namespace MemorySnapshotAnalyzer.Commands
         {
             var sb = new StringBuilder();
             NativeWord address = CurrentTracedHeap.PostorderAddress(nodeIndex);
-            int typeIndex = CurrentTracedHeap.PostorderTypeIndexOrSentinel(nodeIndex);
-            foreach (PointerInfo<NativeWord> pointerInfo in CurrentTraceableHeap.GetPointers(address, typeIndex))
+
+            if (successorNodeIndex != -1)
             {
-                if (pointerInfo.FieldNumber != -1 && CurrentTracedHeap.ObjectAddressToPostorderIndex(pointerInfo.Value) == successorNodeIndex)
+                int typeIndex = CurrentTracedHeap.PostorderTypeIndexOrSentinel(nodeIndex);
+                foreach (PointerInfo<NativeWord> pointerInfo in CurrentTraceableHeap.GetPointers(address, typeIndex))
                 {
-                    if (sb.Length > 0)
+                    if (pointerInfo.FieldNumber != -1 && CurrentTracedHeap.ObjectAddressToPostorderIndex(pointerInfo.Value) == successorNodeIndex)
                     {
-                        sb.Append(", ");
+                        if (sb.Length > 0)
+                        {
+                            sb.Append(", ");
+                        }
+                        else
+                        {
+                            sb.Append(' ');
+                        }
+                        sb.Append(CurrentTraceableHeap.TypeSystem.FieldName(pointerInfo.TypeIndex, pointerInfo.FieldNumber));
                     }
-                    else
-                    {
-                        sb.Append(' ');
-                    }
-                    sb.Append(CurrentTraceableHeap.TypeSystem.FieldName(pointerInfo.TypeIndex, pointerInfo.FieldNumber));
                 }
             }
 


### PR DESCRIPTION
## Issue Description

When running `bt 'lifelines` on an object that has tags associated with it, the tags are not output on the target object itself, only on objects further up in the stack trace.

## Change Description

Fixed conditional such that tags are output on the target object as well.