### PR TITLE
Bug fix: Properly maintain type index when field is found in base type

### DIFF
--- a/AbstractMemorySnapshot/SegmentedHeap.cs
+++ b/AbstractMemorySnapshot/SegmentedHeap.cs
@@ -168,7 +168,7 @@ namespace MemorySnapshotAnalyzer.AbstractMemorySnapshot
                     }
                     else
                     {
-                        fieldNumber = m_typeSystem.GetFieldNumber(typeIndex, fieldName);
+                        (typeIndex, fieldNumber) = m_typeSystem.GetFieldNumber(typeIndex, fieldName);
                         if (fieldNumber == -1)
                         {
                             // TODO: emit warning

--- a/AbstractMemorySnapshot/TypeSystem.cs
+++ b/AbstractMemorySnapshot/TypeSystem.cs
@@ -188,26 +188,30 @@ namespace MemorySnapshotAnalyzer.AbstractMemorySnapshot
             }
         }
 
-        public int GetFieldNumber(int typeIndex, string fieldName)
+        public (int typeIndex, int fieldNumber) GetFieldNumber(int typeIndex, string fieldName)
         {
             if (IsArray(typeIndex))
             {
-                return -1;
+                return (-1, -1);
             }
             else if (IsValueType(typeIndex))
             {
-                return GetOwnFieldNumber(typeIndex, fieldName);
+                return (typeIndex, GetOwnFieldNumber(typeIndex, fieldName));
             }
 
             int currentTypeIndex = typeIndex;
-            int fieldNumber = -1;
-            while (currentTypeIndex != -1 && fieldNumber == -1)
+            do
             {
-                fieldNumber = GetOwnFieldNumber(currentTypeIndex, fieldName);
+                int fieldNumber = GetOwnFieldNumber(currentTypeIndex, fieldName);
+                if (fieldNumber != -1)
+                {
+                    return (currentTypeIndex, fieldNumber);
+                }
                 currentTypeIndex = BaseOrElementTypeIndex(currentTypeIndex);
             }
+            while (currentTypeIndex != -1);
 
-            return fieldNumber;
+            return (-1, -1);
         }
 
         int GetOwnFieldNumber(int typeIndex, string fieldName)

--- a/ReferenceClassifiers/BoundRuleset.cs
+++ b/ReferenceClassifiers/BoundRuleset.cs
@@ -151,7 +151,7 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
                 }
                 else
                 {
-                    fieldNumber = m_typeSystem.GetFieldNumber(currentTypeIndex, fieldNames[i]);
+                    (int baseTypeIndex, fieldNumber) = m_typeSystem.GetFieldNumber(currentTypeIndex, fieldNames[i]);
                     if (fieldNumber == -1)
                     {
                         // TODO: better warning management
@@ -164,6 +164,7 @@ namespace MemorySnapshotAnalyzer.ReferenceClassifiers
                         return new Selector { StaticPrefix = fieldPath, DynamicTail = dynamicFieldNames };
                     }
 
+                    currentTypeIndex = baseTypeIndex;
                     fieldTypeIndex = m_typeSystem.FieldType(currentTypeIndex, fieldNumber);
                 }
 


### PR DESCRIPTION
## Issue Description

We got an exception when writing a selector where a field was found in the base type of a static prefix.

## Change Description

Properly maintain the type index to be the base type as appropriate.