### PR TITLE
Simplify dependencies and load appsettings from binary directory

### DIFF
--- a/MemorySnapshotAnalyzer/MemorySnapshotAnalyzer.csproj
+++ b/MemorySnapshotAnalyzer/MemorySnapshotAnalyzer.csproj
@@ -16,7 +16,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="thirdparty.rcl">
+    <None Update="*.rcl">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="treemap.html">

--- a/MemorySnapshotAnalyzer/Program.cs
+++ b/MemorySnapshotAnalyzer/Program.cs
@@ -9,8 +9,6 @@ using MemorySnapshotAnalyzer.CommandInfrastructure;
 using MemorySnapshotAnalyzer.Commands;
 using MemorySnapshotAnalyzer.UnityBackend;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using System;
 
 static class Program
@@ -18,8 +16,10 @@ static class Program
     [STAThread]
     public static int Main(string[] args)
     {
-        using IHost host = Host.CreateDefaultBuilder(args).Build();
-        IConfiguration configuration = host.Services.GetRequiredService<IConfiguration>();
+        IConfiguration configuration = new ConfigurationBuilder()
+            .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: true)
+            .Build();
 
         using Repl repl = new(configuration);
 

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cp MemorySnapshotAnalyzer/appsettings.json .
-cp MemorySnapshotAnalyzer/thirdparty.rcl .
 exec dotnet run --project MemorySnapshotAnalyzer/MemorySnapshotAnalyzer.csproj


### PR DESCRIPTION
## Issue Description

Simplify dependencies for building and running in other development environments.

## Change Description

* Copy all `*.rcl` files to output directory, not just `thirdparty.rcl` - if other environments locally have more files
* Just build a `Configuration` object, as we don't need an `IHost` object
* Set the path for the `Configuration` object to be the application install directory